### PR TITLE
Fixed error creating a new note

### DIFF
--- a/includes/ddnotes_model.php
+++ b/includes/ddnotes_model.php
@@ -498,7 +498,7 @@ class ddnotes_model
         $query = sprintf(
             "UPDATE " . $db->table_name(static::$tablename, true)
                 . " SET "
-                . " `title` = \"%s\", `content` = \"%s\", `file_size` = %d, `ts_updated` = \"%s\""
+                . " `title` = '%s', `content` = '%s', `file_size` = %d, `ts_updated` = '%s'"
                 . " WHERE `id` = %d "
                 . " AND `user_id` = %d",
             $db->escape($this->title),
@@ -514,7 +514,7 @@ class ddnotes_model
             $query = sprintf(
                 "UPDATE " . $db->table_name(static::$tablename, true)
                     . " SET "
-                    . " `title` = \"%s\", `ts_updated` = \"%s\""
+                    . " `title` = '%s', `ts_updated` = '%s'"
                     . " WHERE `id` = %d "
                     . " AND `user_id` = %d",
                 $db->escape($this->title),
@@ -537,9 +537,9 @@ class ddnotes_model
                 "INSERT INTO " . $db->table_name(static::$tablename, true) . " SET "
                     . "`parent_id` = %d, "
                     . "`user_id` = %d, "
-                    . "`title` = \"%s\", "
-                    . "`mimetype` = \"%s\", "
-                    . "`content` = \"%s\", "
+                    . "`title` = '%s', "
+                    . "`mimetype` = '%s', "
+                    . "`content` = '%s', "
                     . "`file_size` = %d",
                 $this->parent_id,
                 $this->user_id,

--- a/skins/elastic/js/main.js
+++ b/skins/elastic/js/main.js
@@ -236,7 +236,7 @@ $(function () {
         rcmail.addEventListener("plugin.delete", function (response) {
             hide_all();
             reset_form();
-            load_notes(-1);
+            refresh_list();
         });
 
         rcmail.addEventListener("plugin.uploaded", function (response) {


### PR DESCRIPTION
# Error creating a new note.

 - Fix due to #6 
At SQL sentences, on databases with `ANSI_QUOTES` mode, the `"` character can be used to enclose identifiers just like `. Changed doublequotes for singlequotes.

- Other fixes
Also fixed a wrong behavior with `Elastic theme` when the last note is deleted. The note list didn't get empty automatically.

